### PR TITLE
Add support for scoped modules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,9 +3,9 @@ var fs         = require('fs');
 var path       = require('path');
 var Module     = require('module');
 var detective  = require('detective');
-var builtins   = require('builtins');
 var glob       = require('glob');
 var util       = require('util');
+var modules    = require('./modules');
 
 exports.lint = function(opts) {
   // pre-load all "--require" files
@@ -38,13 +38,11 @@ exports.lint = function(opts) {
       throw ex;
     }
     requires.forEach(function(req) {
-      if (req.match(/^\./)) {
+      if (modules.isRelative(req)) {
         Module._load(req, parent);
       } else {
-        var core = builtins.indexOf(req) > -1;
-        if (!core) {
-          var moduleName = req.match(/[^\/]+/)[0];
-          dependencies.push(moduleName);
+        if (!modules.isCore(req)) {
+          dependencies.push(modules.name(req));
         }
       }
     });

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -1,0 +1,14 @@
+var builtins = require('builtins');
+
+exports.isRelative = function(path) {
+  return /^\./.test(path);
+};
+
+exports.isCore = function(path) {
+  return builtins.indexOf(path) > -1;
+};
+
+exports.name = function(path) {
+  var index = (path[0] === '@') ? 2 : 1;
+  return path.split('/').slice(0, index).join('/');
+};

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "require-lint": "./bin/cmd.js"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha"
+    "test": "mocha"
   },
   "dependencies": {
     "lodash": "^2.4.1",

--- a/test/end-to-end.spec.js
+++ b/test/end-to-end.spec.js
@@ -154,6 +154,21 @@ describe('require lint', function() {
 
   });
 
+  describe('scoped modules', function() {
+
+    it('can process module names with a @scope', function(done) {
+      test([
+        '--pkg ' + __dirname + '/scopes/package.json',
+      ], function(exitCode, stdout, stderr) {
+        exitCode.should.be.above(0);
+        stderr.should.containEql('Missing dependencies: @scope/missing');
+        stderr.should.containEql('Extraneous dependencies: @scope/extra');
+        done();
+      });
+    });
+
+  });
+
   function test(flags, callback) {
     var binary = path.resolve('./bin/cmd.js')
     exec(binary + ' ' + flags.join(' '),  function (error, stdout, stderr) {

--- a/test/modules.spec.js
+++ b/test/modules.spec.js
@@ -1,0 +1,37 @@
+var should  = require('should');
+var modules = require('../lib/modules.js');
+
+describe('modules', function() {
+
+  it('recognises relative modules', function() {
+    modules.isRelative('./foo').should.eql(true);
+    modules.isRelative('./foo.js').should.eql(true);
+  });
+
+  it('recognises node_modules', function() {
+    modules.isRelative('foo').should.eql(false);
+    modules.isRelative('foo.js').should.eql(false);
+  });
+
+  it('recognises core modules', function() {
+    modules.isCore('fs').should.eql(true);
+    modules.isCore('foobar').should.eql(false);
+  });
+
+  it('gets the module name', function() {
+    modules.name('foo').should.eql('foo');
+  });
+
+  it('gets the module name even with a subfolder', function() {
+    modules.name('foo/bar').should.eql('foo');
+  });
+
+  it('gets scoped module names', function() {
+    modules.name('@scope/foo').should.eql('@scope/foo');
+  });
+
+  it('gets scoped module names even with a subfolder', function() {
+    modules.name('@scope/foo/bar').should.eql('@scope/foo');
+  });
+
+});

--- a/test/scopes/lib.js
+++ b/test/scopes/lib.js
@@ -1,0 +1,7 @@
+
+// not a scope, just peeking into a regular package
+require('regular/peeking-in');
+
+// some scoped modules
+require('@scope/present');
+require('@scope/missing');

--- a/test/scopes/package.json
+++ b/test/scopes/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "test-package",
+  "version": "0.0.0",
+  "main": "lib.js",
+  "dependencies": {
+    "regular": "1.0.0",
+    "@scope/present": "1.0.0",
+    "@scope/extra": "1.0.0"
+  }
+}


### PR DESCRIPTION
@TabDigital/ping-api 
Didn't support scoped modules, because it thought the module name for `@foo/bar` was `@foo`.