### PR TITLE
fix(main): remove duplicates for missing dependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,7 @@ exports.lint = function(opts) {
     throw new Error('No entry points found, please specify --src');
   }
   var dependencies = [];
+  var dependencyCache = {};
 
   // override of Module._compile
   // to find all call to "require"
@@ -42,7 +43,11 @@ exports.lint = function(opts) {
         Module._load(req, parent);
       } else {
         if (!modules.isCore(req)) {
-          dependencies.push(modules.name(req));
+          var moduleName = modules.name(req);
+          if(!dependencyCache[moduleName]) {
+            dependencies.push(moduleName);
+            dependencyCache[moduleName] = true;
+          }
         }
       }
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,6 @@ exports.lint = function(opts) {
     throw new Error('No entry points found, please specify --src');
   }
   var dependencies = [];
-  var dependencyCache = {};
 
   // override of Module._compile
   // to find all call to "require"
@@ -43,11 +42,7 @@ exports.lint = function(opts) {
         Module._load(req, parent);
       } else {
         if (!modules.isCore(req)) {
-          var moduleName = modules.name(req);
-          if(!dependencyCache[moduleName]) {
-            dependencies.push(moduleName);
-            dependencyCache[moduleName] = true;
-          }
+          dependencies.push(modules.name(req));
         }
       }
     });
@@ -68,7 +63,7 @@ exports.lint = function(opts) {
 
   // find all differences
   var pkgDependencies = Object.keys(pkg.dependencies || {});
-
+  dependencies = _.uniq(dependencies);
   return {
     missing: _.difference(dependencies, pkgDependencies, opts.ignoreMissing),
     extra:   _.difference(pkgDependencies, dependencies, opts.ignoreExtra)

--- a/test/duplicate/index.js
+++ b/test/duplicate/index.js
@@ -1,0 +1,8 @@
+// require core module
+require('path');
+
+// missing dependency
+require('express');
+
+// require relative module
+require('./lib');

--- a/test/duplicate/lib.js
+++ b/test/duplicate/lib.js
@@ -1,0 +1,5 @@
+// require core module
+require('fs');
+
+// duplicated missing dependency
+require('express');

--- a/test/duplicate/package.json
+++ b/test/duplicate/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-package",
+  "version": "0.0.0",
+  "main": "index.js"
+}

--- a/test/end-to-end.spec.js
+++ b/test/end-to-end.spec.js
@@ -76,6 +76,16 @@ describe('require lint', function() {
       });
     });
 
+    it('should not duplicate module name in error message', function(done) {
+      test([
+        '--pkg ' + __dirname + '/duplicate/package.json',
+      ], function(exitCode, stdout, stderr) {
+        exitCode.should.be.above(0);
+        stderr.should.not.containEql('Missing dependencies: express, express');
+        done();
+      });
+    });
+
     it('should handle module with special names', function(done) {
       test([
         '--pkg ' + __dirname + '/special/package.json'


### PR DESCRIPTION
@rprieto @srushti @vickvu @deancouch 

When a dependency is missing, it should only be printed out once

e.g. `Missing dependencies express`

rather than 
`Missing dependencies express, express`