### PR TITLE
Add support for .requirelintrc file

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -2,7 +2,7 @@
 
 var util     = require('util');
 var path     = require('path');
-var minimist = require('minimist');
+var rc       = require('rc');
 var index    = require('../lib/index');
 
 function list(arg) {
@@ -11,7 +11,7 @@ function list(arg) {
   else return [];
 }
 
-var args = minimist(process.argv.slice(2));
+var args = rc('requirelint');
 
 try {
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "detective": "^4.3.1",
     "glob": "^7.0.0",
     "lodash": "^4.5.1",
-    "minimist": "^1.2.0"
+    "rc": "^1.2.1"
   },
   "devDependencies": {
     "coffee-script": "~1.7.1",

--- a/test/end-to-end.spec.js
+++ b/test/end-to-end.spec.js
@@ -179,9 +179,29 @@ describe('require lint', function() {
 
   });
 
-  function test(flags, callback) {
+  describe('config file', function() {
+
+    it('can load config from a .requirelintrc file at the root', function(done) {
+      test(__dirname + '/rc', [], function(exitCode, stdout, stderr) {
+        console.log(stdout, stderr)
+        exitCode.should.eql(0);
+        stderr.should.eql('');
+        stderr.should.eql('');
+        done();
+      });
+    });
+
+  });
+
+  function test(cwd, flags, callback) {
+    if (!callback) {
+      callback = flags
+      flags = cwd
+      cwd = null
+    }
     var binary = path.resolve('./bin/cmd.js')
-    exec(binary + ' ' + flags.join(' '),  function (error, stdout, stderr) {
+    var options = cwd ? {cwd:cwd} : {}
+    exec(binary + ' ' + flags.join(' '),  options, function (error, stdout, stderr) {
       callback(error ? error.code : 0, stdout, stderr);
     });
   }

--- a/test/rc/.requirelintrc
+++ b/test/rc/.requirelintrc
@@ -1,0 +1,2 @@
+ignore-missing=missing
+ignore-extra=express

--- a/test/rc/index.js
+++ b/test/rc/index.js
@@ -1,0 +1,5 @@
+// valid dependency
+require('lodash');
+
+// missing dependency
+require('missing');

--- a/test/rc/package.json
+++ b/test/rc/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "test-package",
+  "version": "0.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "lodash": "*",
+    "express": "*"
+  }
+}


### PR DESCRIPTION
Projects can now also pass options using a `.requirelintrc` file, or any of the other variants that https://www.npmjs.com/package/rc supports. The file can be INI or JSON format, for example:

```ini
ignore-missing=mocha
ignore-extra=express
```

This simply complements the command-line arguments (if any).